### PR TITLE
easier install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+ include torahcodes/resources/data/*

--- a/README.md
+++ b/README.md
@@ -10,15 +10,33 @@ Torah Codes , An understandable Equidistant Letter Sequence, multilanguaje and m
 ![image](https://user-images.githubusercontent.com/60758685/172951901-fc5d60fe-8bb5-4522-b172-4013d16d279b.png)
 
 
-## Install 
+## Install (System / Debian-based)
 
 ```
 
-pip3 install torahcodes
+sudo apt install python3 python3-pip
+
+pip3 install git+https://github.com/pedroelbanquero/torahcodespython
 
 tbc-cli
 
 ```
+
+
+## Install (Venv / Debian-based)
+
+```
+
+sudo apt install python3 python3-pip python3-venv
+
+python3 -m venv ./venv
+
+./venv/bin/pip install git+https://github.com/pedroelbanquero/torahcodespython
+
+./venv/bin/tbc-cli
+
+```
+
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,16 @@ setup(
     long_description_content_type='text/markdown',
     url='',
     #packages=find_packages(exclude=['tests']),
-    packages=['torahcodes', 'torahcodes/modules', 'torahcodes/resources/func', 'torahcodes/resources/data'],
+    packages=[
+        'torahcodes',
+        'torahcodes.modules',
+        'torahcodes.resources.func',
+        'torahcodes.resources.data',
+    ],
+    package_data={
+        'torahcodes.resources.data': ['*'],
+    },
+    include_package_data=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -36,7 +45,12 @@ setup(
         'lxml',
         'python-hebrew-numbers',
         'textblob',
-        'deep_translator'
+        'deep_translator',
+        'requests',
+        'pandas',
+        'xgboost',
+        'elasticsearch',
+        'python-telegram-bot',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
easier install - ensure setup.py installs all requirements and the books (data)
after the PR, the package can completely installed (including all requirements and books data) with
`pip install git+https://github.com/pedroelbanquero/torahcodespython`
the MANIFEST.in ensures, that the books data is also included when building a source distribution with
`python setup.py sdist`